### PR TITLE
Github Action for auto publishing package to PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1,0 +1,51 @@
+name: Publish Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+
+    #----------------------------------------------
+    #       check-out repo and set-up python     
+    #----------------------------------------------
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2.2.2
+      with:
+        python-version: 3.9
+
+    #----------------------------------------------
+    #          install & configure poetry         
+    #----------------------------------------------
+    - name: Install Poetry
+      uses: snok/install-poetry@v1.1.6
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    #----------------------------------------------
+    #            install dependencies
+    #----------------------------------------------
+    - name: Install dependencies
+      run: poetry install --no-interaction
+
+    #----------------------------------------------
+    #                 build dist
+    #----------------------------------------------
+    - name: Build source and wheel archives
+      run: poetry build
+
+    #----------------------------------------------
+    #          publish package to PyPI     
+    #----------------------------------------------
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.2.2
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This PR adds a github action that automatically publishes a release of the package to PyPI when you create a release through the github interface.