### PR TITLE
update version number automatically on PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -39,7 +39,9 @@ jobs:
     #                 build dist
     #----------------------------------------------
     - name: Build source and wheel archives
-      run: poetry build
+      run: |
+        poetry version $(git describe --tags --abbrev=0)
+        poetry build
 
     #----------------------------------------------
     #          publish package to PyPI     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "schemasheets"
-version = "0.1.4"
+version = "0.0.0"
 description = "Package to author schemas using spreadsheets"
 authors = ["cmungall <cjm@berkeleybop.org>"]
 


### PR DESCRIPTION
Similar to the model `linkml-runtime` repo, configure Github Actions to automatically update the version number by pulling it from the tag, everytime we create a release through the Github interface.