### PR TITLE
explicitly instantiate example *values*, in order to eliminate "argument must be a mapping, not extended_str" error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 
+examples/output
+
 .idea
 conf/*json
 .cogs

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,6 @@ serve:
 
 gh-deploy:
 	$(RUN) mkdocs gh-deploy
+
+examples/output/examples.yaml: examples/input/schema.tsv examples/input/examples.tsv
+	$(RUN) sheets2linkml --output $@ $^

--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,14 @@ serve:
 gh-deploy:
 	$(RUN) mkdocs gh-deploy
 
-examples/output/examples.yaml: examples/input/schema.tsv examples/input/examples.tsv
+examples/output/single_examples.yaml: examples/input/schema.tsv examples/input/prefixes.tsv examples/input/single_examples.tsv
 	$(RUN) sheets2linkml --output $@ $^
+
+
+examples/output/multiple_examples_per_slot.yaml: examples/input/schema.tsv examples/input/prefixes.tsv examples/input/multiple_examples_per_slot.tsv
+	$(RUN) sheets2linkml --output $@ $^
+
+.PHONY: clean all test gh-deploy serve datamodel-docs sync-examples cogs-% all_py
+
+clean:
+	rm -rf examples/output/*examples*yaml

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ gh-deploy:
 
 examples/output/single_examples.yaml: examples/input/schema.tsv examples/input/prefixes.tsv examples/input/single_examples.tsv
 	$(RUN) sheets2linkml --output $@ $^
+	$(RUN) python schemasheets/schemaview_vs_examples.py
 
 
 examples/output/multiple_examples_per_slot.yaml: examples/input/schema.tsv examples/input/prefixes.tsv examples/input/multiple_examples_per_slot.tsv
@@ -41,3 +42,4 @@ examples/output/multiple_examples_per_slot.yaml: examples/input/schema.tsv examp
 
 clean:
 	rm -rf examples/output/*examples*yaml
+	rm -rf examples/output/*ttl

--- a/examples/input/examples.tsv
+++ b/examples/input/examples.tsv
@@ -1,0 +1,3 @@
+class	slot	description	examples
+> class	slot	description	examples
+for_example	for_example	terms for testing example creation	for example, do not crash

--- a/examples/input/examples.tsv
+++ b/examples/input/examples.tsv
@@ -1,3 +1,0 @@
-class	slot	description	examples
-> class	slot	description	examples
-for_example	for_example	terms for testing example creation	for example, do not crash

--- a/examples/input/multiple_examples_per_slot.tsv
+++ b/examples/input/multiple_examples_per_slot.tsv
@@ -1,0 +1,6 @@
+class	slot	description	examples
+> class	slot	description	examples
+>			"internal_separator: ""|"""
+class_for_example			
+	slot_for_example	terms for testing example creation	for example, do not crash|never ever crash
+class_for_example	slot_for_example		

--- a/examples/input/multiple_examples_per_slot.tsv
+++ b/examples/input/multiple_examples_per_slot.tsv
@@ -1,6 +1,6 @@
 class	slot	description	examples
 > class	slot	description	examples
->			"internal_separator: ""|"""
+>			internal_separator: "|"
 class_for_example			
 	slot_for_example	terms for testing example creation	for example, do not crash|never ever crash
 class_for_example	slot_for_example		

--- a/examples/input/single_examples.tsv
+++ b/examples/input/single_examples.tsv
@@ -1,0 +1,5 @@
+class	slot	description	example
+> class	slot	description	examples
+class_for_example			
+	slot_for_example	terms for testing example creation	for example, do not crash
+class_for_example	slot_for_example		

--- a/examples/input/single_examples.tsv
+++ b/examples/input/single_examples.tsv
@@ -2,4 +2,6 @@ class	slot	description	example
 > class	slot	description	examples
 class_for_example			
 	slot_for_example	terms for testing example creation	for example, do not crash
-class_for_example	slot_for_example		
+	sfe2	terms for testing example creation	never ever crash
+class_for_example	slot_for_example
+class_for_example	sfe2

--- a/schemasheets/schemamaker.py
+++ b/schemasheets/schemamaker.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import List, Union, Any, Dict, Tuple, Generator, TextIO
 
 from linkml_runtime.dumpers import yaml_dumper
-from linkml_runtime.linkml_model import Annotation
+from linkml_runtime.linkml_model import Annotation, Example
 from linkml_runtime.linkml_model.meta import SchemaDefinition, ClassDefinition, Prefix, \
     SlotDefinition, EnumDefinition, PermissibleValue, SubsetDefinition, TypeDefinition, Element
 from linkml_runtime.utils.schemaview import SchemaView, re
@@ -301,7 +301,10 @@ class SchemaMaker:
                     if cc.maps_to == 'cardinality':
                         self.set_cardinality(actual_element, v)
                     elif cc.metaslot:
-                        if cc.maps_to == 'annotations' and not cc.settings.inner_key:
+                        if cc.maps_to == 'examples':
+                            for vi in v:
+                                actual_element.examples.append(Example(value=vi))
+                        elif cc.maps_to == 'annotations' and not cc.settings.inner_key:
                             anns = yaml.load(v[0])
                             for ann_key, ann_val in anns.items():
                                 actual_element.annotations[ann_key] = ann_val

--- a/schemasheets/schemaview_vs_examples.py
+++ b/schemasheets/schemaview_vs_examples.py
@@ -1,0 +1,2 @@
+from linkml_runtime import SchemaView
+se_sv = SchemaView('examples/output/single_examples.yaml')


### PR DESCRIPTION
#23 

Individual examples at least are being created now, but I didn't do anything except add an example rule in the `Makefile`

