### PR TITLE
Issue 25 range override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 
 examples/output
 
+bin
+
+# open office tmp files
+*#
+
 .idea
 conf/*json
 .cogs

--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,10 @@ examples/output/range_override_examples_reasoned.ttl: examples/output/range_over
 	@echo But Makefile keeps going!?
 	- grep -i error $@
 
+configured_owl_via_project: examples/output/range_override_examples.yaml
+	$(RUN) gen-project \
+		--include owl \
+		--generator-arguments 'owl: {type-objects: false}' \
+		--dir examples/output $<
+
+

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,27 @@ examples/output/single_examples.yaml: examples/input/schema.tsv examples/input/p
 examples/output/multiple_examples_per_slot.yaml: examples/input/schema.tsv examples/input/prefixes.tsv examples/input/multiple_examples_per_slot.tsv
 	$(RUN) sheets2linkml --output $@ $^
 
-.PHONY: clean all test gh-deploy serve datamodel-docs sync-examples cogs-% all_py
+.PHONY: clean all test gh-deploy serve datamodel-docs sync-examples cogs-% all_py range_override_reasoning
 
 clean:
-	rm -rf examples/output/*examples*yaml
+	rm -rf examples/output/*examples*yaml*
+
+bin/robot.jar:
+	curl -s https://api.github.com/repos/ontodev/robot/releases/latest  | grep 'browser_download_url.*\.jar"' |  cut -d : -f 2,3 | tr -d \" | wget -O $@ -i -
+
+examples/output/range_override_examples.yaml: examples/input/schema.tsv examples/input/prefixes.tsv examples/input/range_override.tsv
+	$(RUN) sheets2linkml --output $@ $^
+
+
+examples/output/range_override_examples.ttl: examples/output/range_override_examples.yaml
+	$(RUN) gen-owl --output $@ --no-type-objects --no-metaclasses $<
+	# ERROR:root:Multiple slots with URI: https://w3id.org/linkml/examples/personinfo/slot_for_range_override:
+	# ['slot_for_range_override', 'class_for_range_override_slot_for_range_override']; consider giving each a unique slot_uri
+
+examples/output/range_override_examples_reasoned.ttl: examples/output/range_override_examples.ttl bin/robot.jar
+	# error doesn't appear in the generated examples/output/range_override_examples.ttl
+	- grep -i error $<
+	java -jar bin/robot.jar reason --reasoner ELK --input $< --output $@
+	@echo But Makefile keeps going!?
+	- grep -i error $@
+

--- a/bin/placeholder.txt
+++ b/bin/placeholder.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/examples/input/range_override.tsv
+++ b/examples/input/range_override.tsv
@@ -1,0 +1,8 @@
+class	slot	description	range	enum	permissible_value
+> class	slot	description	range	enum	permissible_value
+class_for_range_override					
+	slot_for_range_override	terms for testing range override			
+class_for_range_override	slot_for_range_override		enum_for_range_override		
+				enum_for_range_override	one
+				enum_for_range_override	two
+				enum_for_range_override	three


### PR DESCRIPTION
issue #25

My contributions from #24 also got committed here

The [range override and OWL consequences](https://docs.google.com/document/d/1OOgBRPYVwcD0hbKc79EOKP750vVCLEKAtbztSMQdC7A/edit#bookmark=id.cy8v4gd7mbkk) are triggered by `make examples/output/range_override_examples_reasoned.ttl`