### PR TITLE
Test and fix for #70, linkmk2sheets for prefixes

### DIFF
--- a/tests/test_schema_exporter.py
+++ b/tests/test_schema_exporter.py
@@ -20,6 +20,7 @@ MINISHEET = os.path.join(OUTPUT_DIR, 'mini.tsv')
 TEST_SPEC = os.path.join(INPUT_DIR, 'test-spec.tsv')
 ENUM_SPEC = os.path.join(INPUT_DIR, 'enums.tsv')
 TYPES_SPEC = os.path.join(INPUT_DIR, 'types.tsv')
+PREFIXES_SPEC = os.path.join(INPUT_DIR, 'prefixes.tsv')
 SLOT_SPEC = os.path.join(INPUT_DIR, 'slot-spec.tsv')
 
 EXPECTED = [
@@ -170,6 +171,20 @@ def test_enums():
     e = schema.enums['E']
     e.description = 'test desc'
     _roundtrip(schema, ENUM_SPEC)
+
+
+def test_prefixes():
+    """
+    tests a specification that is dedicated to prefixes
+    """
+    sb = SchemaBuilder()
+    sb.add_prefix("ex", "https://example.org/")
+    sb.add_defaults()
+    schema = sb.schema
+    schema_recapitulated = _roundtrip(schema, PREFIXES_SPEC)
+    assert "ex" in schema_recapitulated.prefixes
+    assert schema_recapitulated.prefixes["ex"].prefix_reference == "https://example.org/"
+    assert "linkml" in schema_recapitulated.prefixes
 
 
 def test_types():


### PR DESCRIPTION
This test uses SchemaBuilder to generate a fake schema with
only prefixes in it

We then use the generic roundtripping mechanism in the
test framework to see if we can go Schema->TSV->Schema,
retaining the prefixes

This uses a simple TSV specification with two columns:

 - prefix
 - prefix_reference

As expected, this test failed, so we included a fix here.

The bug was simply that Prefix was not considered among
the list of possible Elements (it's not really an element
in the same way Class, Slot, etc are).

To fix this we add a condition checking to see if there is
a column 'prefix', and if so, if a prefix object is passed,
then use the prefix column as the primary ID (i.e prefix_prefix)

Fixes #70
