### PR TITLE
Issue 76 schema template

### DIFF
--- a/schemasheets/schema_exporter.py
+++ b/schemasheets/schema_exporter.py
@@ -8,13 +8,13 @@ from typing import Dict, Any, List, Optional, TextIO, Union
 import click
 from linkml_runtime.linkml_model import Element, SlotDefinition, SubsetDefinition, ClassDefinition, EnumDefinition, \
     PermissibleValue, \
-    TypeDefinition, Example, Annotation, Prefix
+    TypeDefinition, Example, Annotation, Prefix, SchemaDefinition
 from linkml_runtime.utils.formatutils import underscore
 from linkml_runtime.utils.schemaview import SchemaView
 
 from schemasheets.schemamaker import SchemaMaker
 from schemasheets.schemasheet_datamodel import TableConfig, T_CLASS, T_SLOT, SchemaSheet, T_ENUM, T_PV, T_TYPE, \
-    T_SUBSET, T_PREFIX
+    T_SUBSET, T_PREFIX, T_SCHEMA
 
 ROW = Dict[str, Any]
 
@@ -136,6 +136,9 @@ class SchemaExporter:
                     pk_col = col_name
                 elif t == T_PREFIX and isinstance(element, Prefix):
                     pk_col = col_name
+                elif t == T_SCHEMA:
+                    pk_col = col_name
+                    print(pk_col)
                 else:
                     logging.warning(f"Not implemented: {t}")
         if not pk_col:

--- a/schemasheets/schema_exporter.py
+++ b/schemasheets/schema_exporter.py
@@ -136,9 +136,9 @@ class SchemaExporter:
                     pk_col = col_name
                 elif t == T_PREFIX and isinstance(element, Prefix):
                     pk_col = col_name
-                elif t == T_SCHEMA:
+                elif t == T_SCHEMA and isinstance(element, SchemaDefinition):
                     pk_col = col_name
-                    print(pk_col)
+                    # print(pk_col)
                 else:
                     logging.warning(f"Not implemented: {t}")
         if not pk_col:

--- a/tests/input/schema_metadata.tsv
+++ b/tests/input/schema_metadata.tsv
@@ -1,0 +1,2 @@
+schema	title
+> schema	prefix_reference

--- a/tests/input/schema_metadata.tsv
+++ b/tests/input/schema_metadata.tsv
@@ -1,2 +1,2 @@
 schema	title
-> schema	prefix_reference
+> schema	title

--- a/tests/test_schema_exporter.py
+++ b/tests/test_schema_exporter.py
@@ -20,6 +20,7 @@ MINISHEET = os.path.join(OUTPUT_DIR, 'mini.tsv')
 TEST_SPEC = os.path.join(INPUT_DIR, 'test-spec.tsv')
 ENUM_SPEC = os.path.join(INPUT_DIR, 'enums.tsv')
 TYPES_SPEC = os.path.join(INPUT_DIR, 'types.tsv')
+PREFIXES_SPEC = os.path.join(INPUT_DIR, 'prefixes.tsv')
 SLOT_SPEC = os.path.join(INPUT_DIR, 'slot-spec.tsv')
 
 EXPECTED = [
@@ -170,6 +171,20 @@ def test_enums():
     e = schema.enums['E']
     e.description = 'test desc'
     _roundtrip(schema, ENUM_SPEC)
+
+
+def test_prefixes():
+    """
+    tests a specification that is dedicated to prefixes
+    """
+    sb = SchemaBuilder()
+    sb.add_prefix("ex", "https://example.org/")
+    sb.add_defaults()
+    schema = sb.schema
+    schema_recapitulated = _roundtrip(schema, PREFIXES_SPEC)
+    assert "ex" in schema_recapitulated.prefixes
+    assert schema_recapitulated.prefixes["ex"].prefix_reference == "https://example.org/"
+    assert "linkml" in schema_recapitulated.prefixes
 
 
 def test_types():

--- a/tests/test_schema_exporter.py
+++ b/tests/test_schema_exporter.py
@@ -21,12 +21,13 @@ TEST_SPEC = os.path.join(INPUT_DIR, 'test-spec.tsv')
 ENUM_SPEC = os.path.join(INPUT_DIR, 'enums.tsv')
 TYPES_SPEC = os.path.join(INPUT_DIR, 'types.tsv')
 PREFIXES_SPEC = os.path.join(INPUT_DIR, 'prefixes.tsv')
+SCHEMA_METADATA_SPEC = os.path.join(INPUT_DIR, 'schema_metadata.tsv')
 SLOT_SPEC = os.path.join(INPUT_DIR, 'slot-spec.tsv')
 
 EXPECTED = [
     {
         'field': 'id',
-        'key': 'True',   ## TODO: should be mapped to 'Yes'
+        'key': 'True',  ## TODO: should be mapped to 'Yes'
         'range': 'string',
         'desc': 'any identifier',
         'schema.org': 'identifier',
@@ -48,12 +49,12 @@ EXPECTED = [
     },
     # tests curie contraction
     {
-         'record': 'Person',
-         'field': 'id',
-         'key': 'True',
-         'range': 'string',
-         'desc': 'identifier for a person',
-         'schema.org': 'identifier'
+        'record': 'Person',
+        'field': 'id',
+        'key': 'True',
+        'range': 'string',
+        'desc': 'identifier for a person',
+        'schema.org': 'identifier'
     },
 ]
 
@@ -90,7 +91,7 @@ def _roundtrip(schema: SchemaDefinition, specification: str, must_pass=True) -> 
     exporter = SchemaExporter(schemamaker=sm)
     sv = SchemaView(schema)
     exporter.export(schemaview=sv, specification=specification, to_file=MINISHEET)
-    #for row in exporter.rows:
+    # for row in exporter.rows:
     #    print(row)
     schema2 = sm.create_schema(MINISHEET)
     sv2 = SchemaView(schema2)
@@ -187,6 +188,25 @@ def test_prefixes():
     assert "linkml" in schema_recapitulated.prefixes
 
 
+def test_schema_metadata():
+    """
+    tests a specification that is dedicated to the metadata about a schema
+    """
+    sb = SchemaBuilder()
+
+    sb.add_defaults()
+    schema = sb.schema
+
+    schema_title = "Test Schema"
+
+    schema.title = schema_title
+    schema.name = "TestSchema"
+
+    schema_recapitulated = _roundtrip(schema, SCHEMA_METADATA_SPEC)
+
+    assert schema_recapitulated.title == schema_title
+
+
 def test_types():
     """
     tests a specification that is dedicated to types
@@ -230,6 +250,3 @@ def test_export_metamodel_slots():
     # of this will change
     examples = s['examples']
     assert 'bibo:draft' == examples
-
-
-


### PR DESCRIPTION
#76 

@cmungall I wrote `test_schema_metadata` and added 

```python
elif t == T_SCHEMA and isinstance(element, SchemaDefinition)
```
to `schemasheets/schema_exporter.py`, following your https://github.com/linkml/schemasheets/pull/77

but I think the exporting steps may have to be different, because we won't be iterating over a multiple schema rows, like we would for slots, classes or prefixes.