### PR TITLE
chore: update linkml/jinja2 dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ documentation = "https://github.com/linkml/schemasheets"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-linkml = "~1.3"
-Jinja2 = "^3.0.3"
+linkml = "^1.3"
+Jinja2 = "^3.0"
 ontodev-cogs = "^0.3.3"
 bioregistry = "~0.5"
 


### PR DESCRIPTION
This PR allows [semver compatible](https://python-poetry.org/docs/dependency-specification/#caret-requirements) updates to linkml and jinja2

Required by https://github.com/linkml/linkml-project-cookiecutter/pull/44 