### PR TITLE
adding option to provide an attribute column

### DIFF
--- a/schemasheets/schemasheet_datamodel.py
+++ b/schemasheets/schemasheet_datamodel.py
@@ -23,6 +23,7 @@ ROW = Dict[str, Any]
 T_SCHEMA = 'schema'
 T_CLASS = 'class'
 T_SLOT = 'slot'
+T_ATTRIBUTE = 'attribute'
 T_ENUM = 'enum'
 T_PV = 'permissible_value'
 T_TYPE = 'type'
@@ -34,6 +35,7 @@ tmap = {
     T_SCHEMA: SchemaDefinition,
     T_CLASS: ClassDefinition,
     T_SLOT: SlotDefinition,
+    T_ATTRIBUTE: SlotDefinition,
     T_ENUM: EnumDefinition,
     T_PV: PermissibleValue,
     T_TYPE: TypeDefinition,


### PR DESCRIPTION
closes #135 

Adding support for `attribute` column, so attributes and slots could be used in one schema, e.g.:
```
class	attribute	slot	range	desc
>class	attribute	slot	range	description
ClassA				class A
ClassA		        slot_a	string	slot a
ClassA		        slot_b	int	slot b
ClassA	attr_a		string	        attribute a
ClassA	attr_b		int	        attribute b
```
gives:
```
slots:
  slot_a:
    from_schema: https://identifiers.org/brain-bican/kb-model
  slot_b:
    from_schema: https://identifiers.org/brain-bican/kb-model
classes:
  ClassA:
    description: class A
    from_schema: https://identifiers.org/brain-bican/kb-model
    slots:
    - slot_a
    - slot_b
    slot_usage:
      slot_a:
        description: slot a
        range: string
      slot_b:
        description: slot b
        range: int
    attributes:
      attr_a:
        description: attribute a
        from_schema: https://identifiers.org/brain-bican/kb-model
        range: string
      attr_b:
        description: attribute b
        from_schema: https://identifiers.org/brain-bican/kb-model
        range: int
```
but not sure if this is the best way to do it...


