### PR TITLE
allow for usage of inner_key when list is expected

### DIFF
--- a/schemasheets/schemamaker.py
+++ b/schemasheets/schemamaker.py
@@ -190,7 +190,14 @@ class SchemaMaker:
                                 logging.warning(f'Overwriting value for {k}, was {curr_val}, now {v}')
                                 raise ValueError(f'Cannot reset value for {k}, was {curr_val}, now {v}')
                             if cc.settings.inner_key:
-                                getattr(actual_element, cc.maps_to)[cc.settings.inner_key] = v
+                                if isinstance(getattr(actual_element, cc.maps_to), list):
+                                    if '|' in v:
+                                        vs = v.split('|')
+                                    else:
+                                        vs = [v]
+                                    setattr(actual_element, cc.maps_to, [{cc.settings.inner_key: v} for v in vs])
+                                else:
+                                    getattr(actual_element, cc.maps_to)[cc.settings.inner_key] = v
                             else:
                                 setattr(actual_element, cc.maps_to, v)
                     elif cc.is_element_type:


### PR DESCRIPTION
I had an issue when using `inner_key` to support `any_of` or `exactly_one_of`, because there was no support for list, so I added it to work with example like this:
```
class	slot	range exactly_one_of	  range any_of	      desc
>class	slot	exactly_one_of	          any_of	      description
>		inner_key: range          inner_key: range	
ClassA				                              class A
ClassA	slot_a	int|string	  	                      slot a
ClassA	slot_b		                  int|string	      slot b
```

If there is other way that I should represent `any_of` or `exactly_one_of` please let me know, couldn't find an example