### PR TITLE
adding lists to  set_attr_via_path_accessor 

### DIFF
--- a/tests/input/personinfo_anyof.tsv
+++ b/tests/input/personinfo_anyof.tsv
@@ -1,0 +1,9 @@
+record	field	key	range	any_of_range	desc
+> class	slot	identifier	range	any_of	description
+>				inner_key: range
+	id	yes	string		any identifier
+	description	no	string		a textual description
+Person		n/a	n/a		a person,living or dead
+Person	id	yes	string		identifier for a person
+Person|Organization	name	no	string		full name
+Person	age	no		decimal|integer	age in years

--- a/tests/test_schemamaker.py
+++ b/tests/test_schemamaker.py
@@ -282,3 +282,17 @@ def test_load_table_config():
     assert 'wikidata:Q215627' in person_cls.exact_mappings
     assert 'sdo:Person' in person_cls.exact_mappings
 
+
+def test_classes_slots_anyof():
+    """testing any_of in the slots"""
+    sm = SchemaMaker()
+    schema = sm.create_schema(os.path.join(INPUT_DIR, 'personinfo_anyof.tsv'))
+    logging.info(f'SCHEMA={schema}')
+    logging.info(f'SCHEMA.cl={schema.classes}')
+    logging.info(f'SCHEMA.sl={schema.slots}')
+    yaml_dumper.dump(schema, to_file=os.path.join(OUTPUT_DIR, 'personinfo.yaml'))
+    yaml = yaml_dumper.dumps(schema)
+    logging.info(yaml)
+    person_cls = schema.classes['Person']
+    assert person_cls.slot_usage["age"].any_of[0].range == "decimal"
+    assert person_cls.slot_usage["age"].any_of[1].range == "integer"


### PR DESCRIPTION
I've realized that my examples of `any_of` stopped working, so I'm suggesting some changes to `set_attr_via_path_accessor`. I'm also adding a test.

I'm just not sure if it's ok that after running [SchemaDefinition(**json_dumper.to_dict(self.schema))](https://github.com/linkml/schemasheets/blob/0c320e5559068bb1c38dc0432ce98130de71b481/schemasheets/schemamaker.py#L153) I get `any_of` in the form with `AnonymousSlotExpression`:
```
          'any_of': [AnonymousSlotExpression({'range': 'decimal'}),
            AnonymousSlotExpression({'range': 'integer'})]
``` 