### PR TITLE
Fix missing import re

### DIFF
--- a/schemasheets/schemamaker.py
+++ b/schemasheets/schemamaker.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 from urllib.request import urlopen
 from copy import copy
+import re
 
 import click
 import yaml
@@ -18,7 +19,7 @@ from linkml_runtime.linkml_model import Annotation, Example
 from linkml_runtime.linkml_model.meta import SchemaDefinition, ClassDefinition, Prefix, \
     SlotDefinition, EnumDefinition, PermissibleValue, SubsetDefinition, TypeDefinition, Element, Setting
 from linkml_runtime.utils.schema_as_dict import schema_as_dict
-from linkml_runtime.utils.schemaview import SchemaView, re
+from linkml_runtime.utils.schemaview import SchemaView
 from linkml_runtime.utils.yamlutils import YAMLRoot
 
 from schemasheets.schemasheet_datamodel import ColumnConfig, TableConfig, get_configmodel, get_metamodel, COL_NAME, \


### PR DESCRIPTION
Fix #147.

This line
https://github.com/linkml/schemasheets/blob/bdde85d74637ae116fb5fd64a2e47999a1aebdfb/schemasheets/schemamaker.py#L21

imports the standard library module `re` from `linkml_runtime.utils.schemaview` for some reason.

`linkml_runtime.utils.schemaview` imports `re` from `linkml_runtime.linkml_model.meta` (via `from linkml_runtime.linkml_model.meta import *`)

In linkml-runtime 1.9.0, the `import re` in `linkml_runtime.linkml_model.meta` was removed. As far as I could tell, the `re` module was not used locally in that file in linkml-runtime 1.2.0 to 1.8.3 (I did not check earlier). It's not clear why it was there to begin with.

In any case, since `re` is a standard library, we should just import it directly.